### PR TITLE
Add architecture and API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # task-master-ai
 
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 0.16.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ For more detailed information, check out the documentation in the `docs` directo
 - [Task Structure](docs/task-structure.md) - Understanding the task format and features
 - [Example Interactions](docs/examples.md) - Common Cursor AI interaction examples
 - [Migration Guide](docs/migration-guide.md) - Guide to migrating to the new project structure
+- [Project Architecture](docs/architecture.md) - Overview of how the codebase fits together
+- [API Documentation](docs/api/README.md) - Extend Task Master programmatically
 
 ## Troubleshooting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,12 +11,15 @@ Welcome to the Task Master documentation. Use the links below to navigate to the
 
 - [Command Reference](command-reference.md) - Complete list of all available commands
 - [Task Structure](task-structure.md) - Understanding the task format and features
+- [Project Architecture](architecture.md) - High level overview of the codebase
+- [API Documentation](api/README.md) - Using Task Master programmatically
 
 ## Examples & Licensing
 
 - [Example Interactions](examples.md) - Common Cursor AI interaction examples
 - [Licensing Information](licensing.md) - Detailed information about the license
 - [Dashboard Demo](dashboard/index.html) - Sample web UI for managing your AI team
+- [Changelog Format](changelog-format.md) - How release notes are maintained
 
 ## Need More Help?
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,9 @@
+# API Documentation
+
+This directory contains documentation for using Task Master as a Node module and for integrating with the MCP server.
+
+- **CLI Usage** – see the main [README](../README.md#installation) for command line installation and commands.
+- **Node Module** – import functions from `scripts/` or `src/` to build custom tools.
+- **MCP Server** – the server exposed in `mcp-server/` follows the Model Control Protocol and can be extended with new tools.
+
+Additional pages can be added under this folder to document individual modules or endpoints.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,28 @@
+# Project Architecture
+
+This document provides a high level overview of how Task Master is organized.
+
+## CLI Entry Point
+
+The `index.js` file at the project root exposes the command line interface. It loads the various commands located under `scripts/` and `bin/`.
+
+## MCP Server
+
+The `mcp-server/` directory contains an optional server that implements the Model Control Protocol (MCP). Editors like Cursor can connect to this server to run Task Master commands without leaving the editor.
+
+## Source Modules
+
+Reusable logic and provider integrations live under `src/`. The `ai-providers/` folder contains modules for the different AI services. Utility helpers are located in `src/utils`.
+
+## Scripts
+
+The `scripts/` directory houses most of the task management logic that powers the CLI and MCP tools. Each CLI command maps to a module in `scripts/modules/`.
+
+## Tests
+
+A full suite of unit and integration tests lives in the `tests/` directory. Running `npm test` executes all tests.
+
+## Assets
+
+The `assets/` folder contains default configuration files and IDE integration assets that are copied when a project is initialised.
+

--- a/docs/changelog-format.md
+++ b/docs/changelog-format.md
@@ -1,0 +1,5 @@
+# Changelog Format
+
+Task Master follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) style. Changes are grouped by version and type (Major, Minor, Patch). Version bumps are handled with [Changesets](https://github.com/changesets/changesets).
+
+When adding a user facing change, create a changeset using `npm run changeset`. After release, the summary appears in `CHANGELOG.md` under the appropriate version.


### PR DESCRIPTION
## Summary
- create `docs/api` directory with initial README
- document project architecture in `docs/architecture.md`
- describe changelog format
- link new docs from documentation index and README
- explain changelog format at top of `CHANGELOG.md`

## Testing
- `npm test`
- `npm run format-check`


------
https://chatgpt.com/codex/tasks/task_e_683fc8fc45688329a835a4eec4590d60