### PR TITLE
Implement TaskMasterDataManager

### DIFF
--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -1,0 +1,152 @@
+import fs from 'fs';
+import path from 'path';
+import { TASKMASTER_DIR, TASKMASTER_TASKS_FILE, TASKMASTER_CONFIG_FILE } from '../constants/paths.js';
+import { findProjectRoot } from './path-utils.js';
+import { getLoggerOrDefault } from './logger-utils.js';
+
+/**
+ * Manages reading and writing Task Master data files.
+ */
+export default class TaskMasterDataManager {
+        /**
+         * @param {string|null} projectRoot - Optional project root. Defaults to auto discovery.
+         * @param {Object|null} logger - Optional logger object.
+         */
+        constructor(projectRoot = null, logger = null) {
+                this.projectRoot = projectRoot || findProjectRoot() || process.cwd();
+                this.logger = getLoggerOrDefault(logger);
+        }
+
+        /**
+         * Get the absolute path to the .taskmaster directory.
+         * @returns {string} Directory path.
+         */
+        getTaskmasterDir() {
+                return path.join(this.projectRoot, TASKMASTER_DIR);
+        }
+
+        /**
+         * Ensure the .taskmaster directory exists.
+         * @returns {string|null} Created directory path or null on error.
+         */
+        ensureTaskmasterDir() {
+                const dir = this.getTaskmasterDir();
+                try {
+                        if (!fs.existsSync(dir)) {
+                                fs.mkdirSync(dir, { recursive: true });
+                                this.logger.info(`Created directory: ${dir}`);
+                        }
+                        return dir;
+                } catch (err) {
+                        this.logger.error(`Failed to create directory ${dir}: ${err.message}`);
+                        return null;
+                }
+        }
+
+        /**
+         * Read the contents of a sub directory inside .taskmaster.
+         * @param {string} subDir - Relative sub directory path.
+         * @returns {string[]} Array of file names or empty array on error.
+         */
+        readDirectory(subDir = '') {
+                const dirPath = path.join(this.getTaskmasterDir(), subDir);
+                try {
+                        return fs.readdirSync(dirPath);
+                } catch (err) {
+                        this.logger.error(`Failed to read directory ${dirPath}: ${err.message}`);
+                        return [];
+                }
+        }
+
+        /**
+         * Read and parse a JSON file relative to the project root.
+         * @param {string} relativePath - File path relative to project root.
+         * @returns {Object|null} Parsed data or null on error.
+         */
+        readJSONFile(relativePath) {
+                const filePath = path.join(this.projectRoot, relativePath);
+                try {
+                        const raw = fs.readFileSync(filePath, 'utf8');
+                        return JSON.parse(raw);
+                } catch (err) {
+                        this.logger.error(`Error reading JSON file ${filePath}: ${err.message}`);
+                        return null;
+                }
+        }
+
+        /**
+         * Write data as JSON to a file relative to the project root.
+         * @param {string} relativePath - File path relative to project root.
+         * @param {Object} data - Data to write.
+         * @returns {boolean} True on success, false otherwise.
+         */
+        writeJSONFile(relativePath, data) {
+                const filePath = path.join(this.projectRoot, relativePath);
+                try {
+                        const dir = path.dirname(filePath);
+                        if (!fs.existsSync(dir)) {
+                                fs.mkdirSync(dir, { recursive: true });
+                        }
+                        fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
+                        return true;
+                } catch (err) {
+                        this.logger.error(`Error writing JSON file ${filePath}: ${err.message}`);
+                        return false;
+                }
+        }
+
+        /** Read tasks.json using standard path. */
+        readTasks() {
+                return this.readJSONFile(TASKMASTER_TASKS_FILE);
+        }
+
+        /** Write tasks.json after validation. */
+        writeTasks(data) {
+                if (!this.validateTasksData(data)) {
+                        this.logger.error('Invalid tasks data');
+                        return false;
+                }
+                return this.writeJSONFile(TASKMASTER_TASKS_FILE, data);
+        }
+
+        /** Read config.json using standard path. */
+        readConfig() {
+                return this.readJSONFile(TASKMASTER_CONFIG_FILE);
+        }
+
+        /** Write config.json after validation. */
+        writeConfig(data) {
+                if (!this.validateConfigData(data)) {
+                        this.logger.error('Invalid config data');
+                        return false;
+                }
+                return this.writeJSONFile(TASKMASTER_CONFIG_FILE, data);
+        }
+
+        /**
+         * Validate basic structure of tasks data.
+         * @param {Object} data - Data to validate.
+         * @returns {boolean} True if valid.
+         */
+        validateTasksData(data) {
+                return (
+                        data &&
+                        typeof data === 'object' &&
+                        Array.isArray(data.tasks)
+                );
+        }
+
+        /**
+         * Validate basic structure of config data.
+         * @param {Object} data - Config data.
+         * @returns {boolean} True if valid.
+         */
+        validateConfigData(data) {
+                return (
+                        data &&
+                        typeof data === 'object' &&
+                        typeof data.models === 'object' &&
+                        typeof data.global === 'object'
+                );
+        }
+}

--- a/tests/unit/data-manager.test.js
+++ b/tests/unit/data-manager.test.js
@@ -1,0 +1,86 @@
+/**
+ * TaskMasterDataManager tests
+ */
+
+import { jest } from '@jest/globals';
+import fs from 'fs';
+
+
+jest.mock('../../src/utils/path-utils.js', () => ({
+        __esModule: true,
+        findProjectRoot: jest.fn(() => '/project')
+}));
+
+
+describe('TaskMasterDataManager', () => {
+        let existsSpy;
+        let mkdirSpy;
+        let readSpy;
+        let writeSpy;
+        let TaskMasterDataManager;
+
+        beforeEach(async () => {
+                jest.clearAllMocks();
+                jest.resetModules();
+                existsSpy = jest.spyOn(fs, 'existsSync');
+                mkdirSpy = jest.spyOn(fs, 'mkdirSync');
+                readSpy = jest.spyOn(fs, 'readFileSync');
+                writeSpy = jest.spyOn(fs, 'writeFileSync');
+                const mod = await import('../../src/utils/data-manager.js');
+                TaskMasterDataManager = mod.default;
+        });
+
+        afterEach(() => {
+                existsSpy.mockRestore();
+                mkdirSpy.mockRestore();
+                readSpy.mockRestore();
+                writeSpy.mockRestore();
+        });
+
+        test('ensureTaskmasterDir creates directory when missing', () => {
+                existsSpy.mockReturnValue(false);
+                const manager = new TaskMasterDataManager();
+                const dir = manager.ensureTaskmasterDir();
+                const expectedDir = `${process.cwd()}/.taskmaster`;
+                expect(fs.mkdirSync).toHaveBeenCalledWith(expectedDir, { recursive: true });
+                expect(dir).toBe(expectedDir);
+        });
+
+        test('readJSONFile parses JSON', () => {
+                readSpy.mockReturnValue('{"a":1}');
+                const manager = new TaskMasterDataManager();
+                const data = manager.readJSONFile('.taskmaster/config.json');
+                const expectedPath = `${process.cwd()}/.taskmaster/config.json`;
+                expect(fs.readFileSync).toHaveBeenCalledWith(expectedPath, 'utf8');
+                expect(data).toEqual({ a: 1 });
+        });
+
+        test('readJSONFile returns null on error', () => {
+                readSpy.mockImplementation(() => { throw new Error('fail'); });
+                const manager = new TaskMasterDataManager();
+                const data = manager.readJSONFile('missing.json');
+                expect(data).toBeNull();
+        });
+
+        test('writeJSONFile writes data', () => {
+                existsSpy.mockReturnValue(true);
+                const manager = new TaskMasterDataManager();
+                const result = manager.writeJSONFile('data.json', { x: 2 });
+                const expectedFile = `${process.cwd()}/data.json`;
+                expect(fs.writeFileSync).toHaveBeenCalledWith(expectedFile, JSON.stringify({ x: 2 }, null, 2), 'utf8');
+                expect(result).toBe(true);
+        });
+
+        test('writeJSONFile returns false on error', () => {
+                writeSpy.mockImplementation(() => { throw new Error('fail'); });
+                const manager = new TaskMasterDataManager();
+                const result = manager.writeJSONFile('fail.json', { y: 1 });
+                expect(result).toBe(false);
+        });
+
+        test('validateTasksData checks structure', () => {
+                const manager = new TaskMasterDataManager();
+                expect(manager.validateTasksData({ tasks: [{ id: 1 }] })).toBe(true);
+                expect(manager.validateTasksData({ tasks: {} })).toBe(false);
+        });
+});


### PR DESCRIPTION
## Summary
- add `TaskMasterDataManager` for file I/O in `.taskmaster`
- support JSON parsing/writing with error handling and validation
- test data manager behaviours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fccaf11788329ac49df34c4371dbb