### PR TITLE
Add backward compatible tasks file handling

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -1,0 +1,27 @@
+# Task Master File Formats
+
+This document describes the structure of the core files used by Task Master. It is intended for developers who need to read or generate these files programmatically.
+
+## tasks.json
+
+`tasks.json` is the primary database for all tasks. The file contains a single object with a `tasks` array. Each task has at minimum the following fields:
+
+- `id` *(number)* – unique numeric identifier
+- `title` *(string)* – short description
+- `description` *(string)* – detailed explanation of the task
+- `status` *(string)* – current status (`pending`, `in-progress`, `done`, etc.)
+- `priority` *(string)* – priority level
+- `dependencies` *(number[])* – list of IDs this task depends on
+- `details` *(string, optional)* – implementation notes
+- `testStrategy` *(string, optional)* – how the task is verified
+- `subtasks` *(array, optional)* – nested subtask objects
+
+Extra fields are allowed to maintain compatibility with older formats.
+
+## config.json
+
+Configuration options are stored in `.taskmaster/config.json`. The file contains objects describing model settings and global preferences. Task Master validates that the `models` and `global` keys exist but otherwise preserves unknown fields for forward compatibility.
+
+## Legacy Support
+
+Task Master will automatically look for legacy locations such as `tasks/tasks.json` and `.taskmasterconfig`. When these files are found, a deprecation warning is emitted but the data is still loaded to ensure older projects continue to work. The migration guide provides instructions for moving to the `.taskmaster/` layout.

--- a/src/utils/data-manager.js
+++ b/src/utils/data-manager.js
@@ -1,152 +1,182 @@
 import fs from 'fs';
 import path from 'path';
-import { TASKMASTER_DIR, TASKMASTER_TASKS_FILE, TASKMASTER_CONFIG_FILE } from '../constants/paths.js';
-import { findProjectRoot } from './path-utils.js';
+import {
+	TASKMASTER_DIR,
+	TASKMASTER_TASKS_FILE,
+	TASKMASTER_CONFIG_FILE
+} from '../constants/paths.js';
+import {
+	findProjectRoot,
+	findTasksPath,
+	resolveTasksOutputPath
+} from './path-utils.js';
+import { tasksFileSchema } from './tasks-schema.js';
 import { getLoggerOrDefault } from './logger-utils.js';
 
 /**
  * Manages reading and writing Task Master data files.
  */
 export default class TaskMasterDataManager {
-        /**
-         * @param {string|null} projectRoot - Optional project root. Defaults to auto discovery.
-         * @param {Object|null} logger - Optional logger object.
-         */
-        constructor(projectRoot = null, logger = null) {
-                this.projectRoot = projectRoot || findProjectRoot() || process.cwd();
-                this.logger = getLoggerOrDefault(logger);
-        }
+	/**
+	 * @param {string|null} projectRoot - Optional project root. Defaults to auto discovery.
+	 * @param {Object|null} logger - Optional logger object.
+	 */
+	constructor(projectRoot = null, logger = null) {
+		this.projectRoot = projectRoot || findProjectRoot() || process.cwd();
+		this.logger = getLoggerOrDefault(logger);
+		this.tasksPath = null;
+	}
 
-        /**
-         * Get the absolute path to the .taskmaster directory.
-         * @returns {string} Directory path.
-         */
-        getTaskmasterDir() {
-                return path.join(this.projectRoot, TASKMASTER_DIR);
-        }
+	/**
+	 * Get the absolute path to the .taskmaster directory.
+	 * @returns {string} Directory path.
+	 */
+	getTaskmasterDir() {
+		return path.join(this.projectRoot, TASKMASTER_DIR);
+	}
 
-        /**
-         * Ensure the .taskmaster directory exists.
-         * @returns {string|null} Created directory path or null on error.
-         */
-        ensureTaskmasterDir() {
-                const dir = this.getTaskmasterDir();
-                try {
-                        if (!fs.existsSync(dir)) {
-                                fs.mkdirSync(dir, { recursive: true });
-                                this.logger.info(`Created directory: ${dir}`);
-                        }
-                        return dir;
-                } catch (err) {
-                        this.logger.error(`Failed to create directory ${dir}: ${err.message}`);
-                        return null;
-                }
-        }
+	/**
+	 * Ensure the .taskmaster directory exists.
+	 * @returns {string|null} Created directory path or null on error.
+	 */
+	ensureTaskmasterDir() {
+		const dir = this.getTaskmasterDir();
+		try {
+			if (!fs.existsSync(dir)) {
+				fs.mkdirSync(dir, { recursive: true });
+				this.logger.info(`Created directory: ${dir}`);
+			}
+			return dir;
+		} catch (err) {
+			this.logger.error(`Failed to create directory ${dir}: ${err.message}`);
+			return null;
+		}
+	}
 
-        /**
-         * Read the contents of a sub directory inside .taskmaster.
-         * @param {string} subDir - Relative sub directory path.
-         * @returns {string[]} Array of file names or empty array on error.
-         */
-        readDirectory(subDir = '') {
-                const dirPath = path.join(this.getTaskmasterDir(), subDir);
-                try {
-                        return fs.readdirSync(dirPath);
-                } catch (err) {
-                        this.logger.error(`Failed to read directory ${dirPath}: ${err.message}`);
-                        return [];
-                }
-        }
+	/**
+	 * Read the contents of a sub directory inside .taskmaster.
+	 * @param {string} subDir - Relative sub directory path.
+	 * @returns {string[]} Array of file names or empty array on error.
+	 */
+	readDirectory(subDir = '') {
+		const dirPath = path.join(this.getTaskmasterDir(), subDir);
+		try {
+			return fs.readdirSync(dirPath);
+		} catch (err) {
+			this.logger.error(`Failed to read directory ${dirPath}: ${err.message}`);
+			return [];
+		}
+	}
 
-        /**
-         * Read and parse a JSON file relative to the project root.
-         * @param {string} relativePath - File path relative to project root.
-         * @returns {Object|null} Parsed data or null on error.
-         */
-        readJSONFile(relativePath) {
-                const filePath = path.join(this.projectRoot, relativePath);
-                try {
-                        const raw = fs.readFileSync(filePath, 'utf8');
-                        return JSON.parse(raw);
-                } catch (err) {
-                        this.logger.error(`Error reading JSON file ${filePath}: ${err.message}`);
-                        return null;
-                }
-        }
+	/**
+	 * Read and parse a JSON file relative to the project root.
+	 * @param {string} relativePath - File path relative to project root.
+	 * @returns {Object|null} Parsed data or null on error.
+	 */
+	readJSONFile(relativePath) {
+		const filePath = path.join(this.projectRoot, relativePath);
+		try {
+			const raw = fs.readFileSync(filePath, 'utf8');
+			return JSON.parse(raw);
+		} catch (err) {
+			this.logger.error(`Error reading JSON file ${filePath}: ${err.message}`);
+			return null;
+		}
+	}
 
-        /**
-         * Write data as JSON to a file relative to the project root.
-         * @param {string} relativePath - File path relative to project root.
-         * @param {Object} data - Data to write.
-         * @returns {boolean} True on success, false otherwise.
-         */
-        writeJSONFile(relativePath, data) {
-                const filePath = path.join(this.projectRoot, relativePath);
-                try {
-                        const dir = path.dirname(filePath);
-                        if (!fs.existsSync(dir)) {
-                                fs.mkdirSync(dir, { recursive: true });
-                        }
-                        fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
-                        return true;
-                } catch (err) {
-                        this.logger.error(`Error writing JSON file ${filePath}: ${err.message}`);
-                        return false;
-                }
-        }
+	/**
+	 * Write data as JSON to a file relative to the project root.
+	 * @param {string} relativePath - File path relative to project root.
+	 * @param {Object} data - Data to write.
+	 * @returns {boolean} True on success, false otherwise.
+	 */
+	writeJSONFile(relativePath, data) {
+		const filePath = path.join(this.projectRoot, relativePath);
+		try {
+			const dir = path.dirname(filePath);
+			if (!fs.existsSync(dir)) {
+				fs.mkdirSync(dir, { recursive: true });
+			}
+			fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
+			return true;
+		} catch (err) {
+			this.logger.error(`Error writing JSON file ${filePath}: ${err.message}`);
+			return false;
+		}
+	}
 
-        /** Read tasks.json using standard path. */
-        readTasks() {
-                return this.readJSONFile(TASKMASTER_TASKS_FILE);
-        }
+	/**
+	 * Read tasks.json using fallback search for legacy locations.
+	 * Stores the path that was read for future writes.
+	 */
+	readTasks() {
+		const tasksPath =
+			findTasksPath(null, { projectRoot: this.projectRoot }, this.logger) ||
+			path.join(this.projectRoot, TASKMASTER_TASKS_FILE);
 
-        /** Write tasks.json after validation. */
-        writeTasks(data) {
-                if (!this.validateTasksData(data)) {
-                        this.logger.error('Invalid tasks data');
-                        return false;
-                }
-                return this.writeJSONFile(TASKMASTER_TASKS_FILE, data);
-        }
+		const data = this.readJSONFile(tasksPath);
+		if (data) {
+			this.tasksPath = tasksPath;
+		}
+		return data;
+	}
 
-        /** Read config.json using standard path. */
-        readConfig() {
-                return this.readJSONFile(TASKMASTER_CONFIG_FILE);
-        }
+	/**
+	 * Write tasks.json after validation. Uses previously read path or
+	 * resolves the default output path if none was stored.
+	 */
+	writeTasks(data) {
+		if (!this.validateTasksData(data)) {
+			this.logger.error('Invalid tasks data');
+			return false;
+		}
 
-        /** Write config.json after validation. */
-        writeConfig(data) {
-                if (!this.validateConfigData(data)) {
-                        this.logger.error('Invalid config data');
-                        return false;
-                }
-                return this.writeJSONFile(TASKMASTER_CONFIG_FILE, data);
-        }
+		const outPath =
+			this.tasksPath ||
+			resolveTasksOutputPath(
+				null,
+				{ projectRoot: this.projectRoot },
+				this.logger
+			);
+		this.tasksPath = outPath;
+		return this.writeJSONFile(outPath, data);
+	}
 
-        /**
-         * Validate basic structure of tasks data.
-         * @param {Object} data - Data to validate.
-         * @returns {boolean} True if valid.
-         */
-        validateTasksData(data) {
-                return (
-                        data &&
-                        typeof data === 'object' &&
-                        Array.isArray(data.tasks)
-                );
-        }
+	/** Read config.json using standard path. */
+	readConfig() {
+		return this.readJSONFile(TASKMASTER_CONFIG_FILE);
+	}
 
-        /**
-         * Validate basic structure of config data.
-         * @param {Object} data - Config data.
-         * @returns {boolean} True if valid.
-         */
-        validateConfigData(data) {
-                return (
-                        data &&
-                        typeof data === 'object' &&
-                        typeof data.models === 'object' &&
-                        typeof data.global === 'object'
-                );
-        }
+	/** Write config.json after validation. */
+	writeConfig(data) {
+		if (!this.validateConfigData(data)) {
+			this.logger.error('Invalid config data');
+			return false;
+		}
+		return this.writeJSONFile(TASKMASTER_CONFIG_FILE, data);
+	}
+
+	/**
+	 * Validate basic structure of tasks data.
+	 * @param {Object} data - Data to validate.
+	 * @returns {boolean} True if valid.
+	 */
+	validateTasksData(data) {
+		const result = tasksFileSchema.safeParse(data);
+		return result.success;
+	}
+
+	/**
+	 * Validate basic structure of config data.
+	 * @param {Object} data - Config data.
+	 * @returns {boolean} True if valid.
+	 */
+	validateConfigData(data) {
+		return (
+			data &&
+			typeof data === 'object' &&
+			typeof data.models === 'object' &&
+			typeof data.global === 'object'
+		);
+	}
 }

--- a/src/utils/tasks-schema.js
+++ b/src/utils/tasks-schema.js
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const subtaskSchema = z
+	.object({
+		id: z.number(),
+		title: z.string(),
+		description: z.string(),
+		status: z.string(),
+		dependencies: z.array(z.number()).optional().default([])
+	})
+	.passthrough();
+
+export const taskSchema = z
+	.object({
+		id: z.number(),
+		title: z.string(),
+		description: z.string(),
+		status: z.string(),
+		priority: z.string(),
+		dependencies: z.array(z.number()),
+		details: z.string().optional(),
+		testStrategy: z.string().optional(),
+		subtasks: z.array(subtaskSchema).optional()
+	})
+	.passthrough();
+
+export const tasksFileSchema = z.object({ tasks: z.array(taskSchema) });

--- a/tests/unit/data-manager.test.js
+++ b/tests/unit/data-manager.test.js
@@ -5,82 +5,137 @@
 import { jest } from '@jest/globals';
 import fs from 'fs';
 
-
-jest.mock('../../src/utils/path-utils.js', () => ({
-        __esModule: true,
-        findProjectRoot: jest.fn(() => '/project')
+jest.unstable_mockModule('../../src/utils/path-utils.js', () => ({
+	__esModule: true,
+	findProjectRoot: jest.fn(() => '/project'),
+	findTasksPath: jest.fn(() => '/project/.taskmaster/tasks/tasks.json'),
+	resolveTasksOutputPath: jest.fn(
+		() => '/project/.taskmaster/tasks/tasks.json'
+	),
+	findConfigPath: jest.fn(() => '/project/.taskmaster/config.json'),
+	findPRDPath: jest.fn(() => null),
+	findComplexityReportPath: jest.fn(() => null),
+	resolveComplexityReportOutputPath: jest.fn(() => null)
 }));
 
-
 describe('TaskMasterDataManager', () => {
-        let existsSpy;
-        let mkdirSpy;
-        let readSpy;
-        let writeSpy;
-        let TaskMasterDataManager;
+	let existsSpy;
+	let mkdirSpy;
+	let readSpy;
+	let writeSpy;
+	let TaskMasterDataManager;
 
-        beforeEach(async () => {
-                jest.clearAllMocks();
-                jest.resetModules();
-                existsSpy = jest.spyOn(fs, 'existsSync');
-                mkdirSpy = jest.spyOn(fs, 'mkdirSync');
-                readSpy = jest.spyOn(fs, 'readFileSync');
-                writeSpy = jest.spyOn(fs, 'writeFileSync');
-                const mod = await import('../../src/utils/data-manager.js');
-                TaskMasterDataManager = mod.default;
-        });
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		jest.resetModules();
+		existsSpy = jest.spyOn(fs, 'existsSync');
+		mkdirSpy = jest.spyOn(fs, 'mkdirSync');
+		readSpy = jest.spyOn(fs, 'readFileSync');
+		writeSpy = jest.spyOn(fs, 'writeFileSync');
+		const mod = await import('../../src/utils/data-manager.js');
+		TaskMasterDataManager = mod.default;
+	});
 
-        afterEach(() => {
-                existsSpy.mockRestore();
-                mkdirSpy.mockRestore();
-                readSpy.mockRestore();
-                writeSpy.mockRestore();
-        });
+	afterEach(() => {
+		existsSpy.mockRestore();
+		mkdirSpy.mockRestore();
+		readSpy.mockRestore();
+		writeSpy.mockRestore();
+	});
 
-        test('ensureTaskmasterDir creates directory when missing', () => {
-                existsSpy.mockReturnValue(false);
-                const manager = new TaskMasterDataManager();
-                const dir = manager.ensureTaskmasterDir();
-                const expectedDir = `${process.cwd()}/.taskmaster`;
-                expect(fs.mkdirSync).toHaveBeenCalledWith(expectedDir, { recursive: true });
-                expect(dir).toBe(expectedDir);
-        });
+	test('ensureTaskmasterDir creates directory when missing', () => {
+		existsSpy.mockReturnValue(false);
+		const manager = new TaskMasterDataManager();
+		const dir = manager.ensureTaskmasterDir();
+		const expectedDir = '/project/.taskmaster';
+		expect(fs.mkdirSync).toHaveBeenCalledWith(expectedDir, { recursive: true });
+		expect(dir).toBe(expectedDir);
+	});
 
-        test('readJSONFile parses JSON', () => {
-                readSpy.mockReturnValue('{"a":1}');
-                const manager = new TaskMasterDataManager();
-                const data = manager.readJSONFile('.taskmaster/config.json');
-                const expectedPath = `${process.cwd()}/.taskmaster/config.json`;
-                expect(fs.readFileSync).toHaveBeenCalledWith(expectedPath, 'utf8');
-                expect(data).toEqual({ a: 1 });
-        });
+	test('readJSONFile parses JSON', () => {
+		readSpy.mockReturnValue('{"a":1}');
+		const manager = new TaskMasterDataManager();
+		const data = manager.readJSONFile('.taskmaster/config.json');
+		const expectedPath = '/project/.taskmaster/config.json';
+		expect(fs.readFileSync).toHaveBeenCalledWith(expectedPath, 'utf8');
+		expect(data).toEqual({ a: 1 });
+	});
 
-        test('readJSONFile returns null on error', () => {
-                readSpy.mockImplementation(() => { throw new Error('fail'); });
-                const manager = new TaskMasterDataManager();
-                const data = manager.readJSONFile('missing.json');
-                expect(data).toBeNull();
-        });
+	test('readJSONFile returns null on error', () => {
+		readSpy.mockImplementation(() => {
+			throw new Error('fail');
+		});
+		const manager = new TaskMasterDataManager();
+		const data = manager.readJSONFile('missing.json');
+		expect(data).toBeNull();
+	});
 
-        test('writeJSONFile writes data', () => {
-                existsSpy.mockReturnValue(true);
-                const manager = new TaskMasterDataManager();
-                const result = manager.writeJSONFile('data.json', { x: 2 });
-                const expectedFile = `${process.cwd()}/data.json`;
-                expect(fs.writeFileSync).toHaveBeenCalledWith(expectedFile, JSON.stringify({ x: 2 }, null, 2), 'utf8');
-                expect(result).toBe(true);
-        });
+	test('writeJSONFile writes data', () => {
+		existsSpy.mockReturnValue(true);
+		const manager = new TaskMasterDataManager();
+		const result = manager.writeJSONFile('data.json', { x: 2 });
+		const expectedFile = '/project/data.json';
+		expect(fs.writeFileSync).toHaveBeenCalledWith(
+			expectedFile,
+			JSON.stringify({ x: 2 }, null, 2),
+			'utf8'
+		);
+		expect(result).toBe(true);
+	});
 
-        test('writeJSONFile returns false on error', () => {
-                writeSpy.mockImplementation(() => { throw new Error('fail'); });
-                const manager = new TaskMasterDataManager();
-                const result = manager.writeJSONFile('fail.json', { y: 1 });
-                expect(result).toBe(false);
-        });
+	test('writeJSONFile returns false on error', () => {
+		writeSpy.mockImplementation(() => {
+			throw new Error('fail');
+		});
+		const manager = new TaskMasterDataManager();
+		const result = manager.writeJSONFile('fail.json', { y: 1 });
+		expect(result).toBe(false);
+	});
 
-        test('validateTasksData checks structure', () => {
-                const manager = new TaskMasterDataManager();
-                expect(manager.validateTasksData({ tasks: [{ id: 1 }] })).toBe(true);
-                expect(manager.validateTasksData({ tasks: {} })).toBe(false);
-        });
+	test('validateTasksData checks structure', () => {
+		const manager = new TaskMasterDataManager();
+		const valid = {
+			tasks: [
+				{
+					id: 1,
+					title: 't',
+					description: 'd',
+					status: 'pending',
+					priority: 'high',
+					dependencies: []
+				}
+			]
+		};
+		expect(manager.validateTasksData(valid)).toBe(true);
+		expect(manager.validateTasksData({ tasks: {} })).toBe(false);
+	});
+
+	test('readTasks uses findTasksPath and stores path', () => {
+		readSpy.mockReturnValue('{"tasks": []}');
+		const manager = new TaskMasterDataManager();
+		const data = manager.readTasks();
+		expect(data).toEqual({ tasks: [] });
+		expect(manager.tasksPath).toBe('/project/.taskmaster/tasks/tasks.json');
+	});
+
+	test('writeTasks uses stored path', () => {
+		existsSpy.mockReturnValue(true);
+		writeSpy.mockImplementation(() => {});
+		const manager = new TaskMasterDataManager();
+		manager.tasksPath = '/project/.taskmaster/tasks/tasks.json';
+		const result = manager.writeTasks({
+			tasks: [
+				{
+					id: 1,
+					title: 't',
+					description: 'd',
+					status: 'pending',
+					priority: 'high',
+					dependencies: []
+				}
+			]
+		});
+		expect(fs.writeFileSync).toHaveBeenCalled();
+		expect(result).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary
- load tasks.json from legacy locations using `findTasksPath`
- store output path and validate with `zod` schema
- add `tasksFileSchema` and tests
- document supported file formats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fcff9729883298442b2c067f9707b