### PR TITLE
Implement tasks API endpoints

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from '../mcp-server/src/logger.js';
+import tasksRouter from './routes/tasks.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,12 +12,13 @@ const app = express();
 
 // Middleware
 	app.use(cors({ origin: process.env.CORS_ORIGIN || '*' }));
-	app.use(express.json());
-	app.use((req, _res, next) => {
+app.use(express.json());
+app.use((req, _res, next) => {
 logger.info(`${req.method} ${req.url}`);
 next();
 });
-	app.use(express.static(path.join(__dirname, '../ui/public')));
+app.use(express.static(path.join(__dirname, '../ui/public')));
+app.use('/api/tasks', tasksRouter);
 
 // Health check route
 app.get('/health', (_req, res) => {

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1,0 +1,91 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { z } from 'zod';
+import { readJSON, writeJSON } from '../../scripts/modules/utils.js';
+
+const router = express.Router();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TASKS_FILE = process.env.TASKS_FILE || path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+
+function loadTasks() {
+  const data = readJSON(TASKS_FILE) || { tasks: [] };
+  return Array.isArray(data.tasks) ? data.tasks : [];
+}
+
+function saveTasks(tasks) {
+  writeJSON(TASKS_FILE, { tasks });
+}
+
+const TaskSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  status: z.string().optional(),
+  dependencies: z.array(z.number()).optional(),
+  priority: z.string().optional(),
+  details: z.string().optional(),
+  testStrategy: z.string().optional(),
+});
+
+router.get('/', (req, res, next) => {
+  try {
+    const tasks = loadTasks();
+    res.json({ tasks });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', (req, res, next) => {
+  try {
+    const data = TaskSchema.parse(req.body);
+    const tasks = loadTasks();
+    const newId = tasks.length ? Math.max(...tasks.map((t) => t.id)) + 1 : 1;
+    const newTask = { id: newId, ...data, subtasks: [] };
+    tasks.push(newTask);
+    saveTasks(tasks);
+    res.status(201).json(newTask);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', (req, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const update = TaskSchema.partial().parse(req.body);
+    const tasks = loadTasks();
+    const index = tasks.findIndex((t) => t.id === id);
+    if (index === -1) {
+      res.status(404).json({ error: 'Task not found' });
+      return;
+    }
+    tasks[index] = { ...tasks[index], ...update };
+    saveTasks(tasks);
+    res.json(tasks[index]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', (req, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const tasks = loadTasks();
+    const index = tasks.findIndex((t) => t.id === id);
+    if (index === -1) {
+      res.status(404).json({ error: 'Task not found' });
+      return;
+    }
+    tasks.splice(index, 1);
+    saveTasks(tasks);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/tests/unit/tasks-api.test.js
+++ b/tests/unit/tasks-api.test.js
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { fileURLToPath } from 'url';
+import { jest } from '@jest/globals';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let app;
+let tmpDir;
+let tasksPath;
+
+describe('tasks API', () => {
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+    tasksPath = path.join(tmpDir, 'tasks.json');
+    fs.writeFileSync(tasksPath, JSON.stringify({ tasks: [] }, null, 2));
+    process.env.TASKS_FILE = tasksPath;
+    jest.resetModules();
+    ({ default: app } = await import('../../server/app.js'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.TASKS_FILE;
+  });
+
+  test('GET /api/tasks returns empty list', async () => {
+    const res = await request(app).get('/api/tasks');
+    expect(res.status).toBe(200);
+    expect(res.body.tasks).toEqual([]);
+  });
+
+  test('POST /api/tasks creates task', async () => {
+    const res = await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Test', description: 'Desc' });
+    expect(res.status).toBe(201);
+    expect(res.body.title).toBe('Test');
+
+    const data = JSON.parse(fs.readFileSync(tasksPath, 'utf-8'));
+    expect(data.tasks.length).toBe(1);
+  });
+
+  test('PUT /api/tasks/:id updates task', async () => {
+    await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Test', description: 'Desc' });
+    const res = await request(app)
+      .put('/api/tasks/1')
+      .send({ status: 'done' });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('done');
+  });
+
+  test('DELETE /api/tasks/:id removes task', async () => {
+    await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Test', description: 'Desc' });
+    const res = await request(app).delete('/api/tasks/1');
+    expect(res.status).toBe(204);
+    const data = JSON.parse(fs.readFileSync(tasksPath, 'utf-8'));
+    expect(data.tasks).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add REST routes for tasks CRUD
- wire up new router in Express app
- test tasks API endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd6defbc0832995563556794a6994