### PR TITLE
Implement API status endpoints

### DIFF
--- a/.changeset/project-status-api.md
+++ b/.changeset/project-status-api.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": minor
+---
+
+Add project status, metrics, and health API endpoints with caching.

--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from '../mcp-server/src/logger.js';
 import tasksRouter from './routes/tasks.js';
+import statusRouter from './routes/status.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -21,10 +22,11 @@ next();
 });
 app.use(express.static(path.join(__dirname, '../ui/public')));
 app.use('/api/tasks', tasksRouter);
+app.use('/api', statusRouter);
 
-// Health check route
+// Legacy health check route
 app.get('/health', (_req, res) => {
-	res.json({ status: 'ok' });
+        res.json({ status: 'ok' });
 });
 
 // 404 handler

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -1,0 +1,88 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { LRUCache } from 'lru-cache';
+import { readJSON } from '../../scripts/modules/utils.js';
+import { success } from '../utils/response.js';
+
+const router = express.Router();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TASKS_FILE =
+  process.env.TASKS_FILE ||
+  path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+
+const cache = new LRUCache({ max: 50, ttl: 1000 * 60 });
+
+function loadTasks() {
+  const data = readJSON(TASKS_FILE) || { tasks: [] };
+  return Array.isArray(data.tasks) ? data.tasks : [];
+}
+
+function computeCounts(tasks) {
+  const counts = {};
+  for (const task of tasks) {
+    const status = task.status || 'unknown';
+    counts[status] = (counts[status] || 0) + 1;
+  }
+  return counts;
+}
+
+function getStatusData() {
+  const cached = cache.get('status');
+  if (cached) return cached;
+  const tasks = loadTasks();
+  const counts = computeCounts(tasks);
+  const data = {
+    total: tasks.length,
+    completed: counts.done || 0,
+    pending: counts.pending || 0,
+    inProgress: counts['in-progress'] || 0,
+    blocked: counts.blocked || 0,
+    deferred: counts.deferred || 0,
+    cancelled: counts.cancelled || 0,
+  };
+  cache.set('status', data);
+  return data;
+}
+
+function getMetricsData() {
+  const cached = cache.get('metrics');
+  if (cached) return cached;
+  const tasks = loadTasks();
+  const counts = computeCounts(tasks);
+  const completed = counts.done || 0;
+  const total = tasks.length || 1;
+  const data = {
+    byStatus: counts,
+    completionRate: completed / total,
+  };
+  cache.set('metrics', data);
+  return data;
+}
+
+router.get('/status', (req, res, next) => {
+  try {
+    const data = getStatusData();
+    res.json(success(data));
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/metrics', (req, res, next) => {
+  try {
+    const data = getMetricsData();
+    res.json(success(data));
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/health', (_req, res) => {
+  res.json(success({ status: 'ok' }));
+});
+
+export default router;

--- a/server/utils/response.js
+++ b/server/utils/response.js
@@ -1,0 +1,7 @@
+export function success(data) {
+  return { success: true, data };
+}
+
+export function error(code, message) {
+  return { success: false, error: { code, message } };
+}

--- a/tests/unit/status-api.test.js
+++ b/tests/unit/status-api.test.js
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { fileURLToPath } from 'url';
+import { jest } from '@jest/globals';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let app;
+let tmpDir;
+let tasksPath;
+
+describe('status API', () => {
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+    tasksPath = path.join(tmpDir, 'tasks.json');
+    const tasks = [
+      { id: 1, title: 'A', description: 'd', status: 'done', subtasks: [] },
+      { id: 2, title: 'B', description: 'd', status: 'in-progress', subtasks: [] },
+      { id: 3, title: 'C', description: 'd', status: 'pending', subtasks: [] }
+    ];
+    fs.writeFileSync(tasksPath, JSON.stringify({ tasks }, null, 2));
+    process.env.TASKS_FILE = tasksPath;
+    jest.resetModules();
+    ({ default: app } = await import('../../server/app.js'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.TASKS_FILE;
+  });
+
+  test('GET /api/health', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe('ok');
+  });
+
+  test('GET /api/status', async () => {
+    const res = await request(app).get('/api/status');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.total).toBe(3);
+    expect(res.body.data.completed).toBe(1);
+    expect(res.body.data.inProgress).toBe(1);
+    expect(res.body.data.pending).toBe(1);
+  });
+
+  test('GET /api/metrics', async () => {
+    const res = await request(app).get('/api/metrics');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.byStatus.done).toBe(1);
+    expect(res.body.data.completionRate).toBeCloseTo(1 / 3);
+  });
+});


### PR DESCRIPTION
## Summary
- add status, metrics and health endpoints
- add response formatting helper
- support new routes in Express app
- test API status endpoints
- document change with a changeset

## Testing
- `npx biome format . --write`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fded5685c832982eb94b026e1ce15