### PR TITLE
Implement schema validation and sanitization

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "tasks": [
     {
       "id": 1,

--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from '../mcp-server/src/logger.js';
 import tasksRouter from './routes/tasks.js';
+import sanitizeBody from './middleware/sanitize.js';
+import errorHandler from './middleware/error-handler.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -14,10 +16,10 @@ const app = express();
 
 app.use(cors({ origin: process.env.CORS_ORIGIN || '*' }));
 app.use(express.json());
+app.use(sanitizeBody);
 app.use((req, _res, next) => {
-logger.info(`${req.method} ${req.url}`);
-next();
-
+	logger.info(`${req.method} ${req.url}`);
+	next();
 });
 app.use(express.static(path.join(__dirname, '../ui/public')));
 app.use('/api/tasks', tasksRouter);
@@ -28,17 +30,10 @@ app.get('/health', (_req, res) => {
 });
 
 // 404 handler
-app.use((_req, res, next) => {
-	res.status(404);
-	res.json({ error: 'Not Found' });
+app.use((_req, res) => {
+	res.status(404).json({ error: 'Not Found' });
 });
 
-// Error handler
-// eslint-disable-next-line no-unused-vars
-app.use((err, _req, res, _next) => {
-	logger.error(err);
-	res.status(err.status || 500);
-	res.json({ error: err.message || 'Internal Server Error' });
-});
+app.use(errorHandler);
 
 export default app;

--- a/server/middleware/error-handler.js
+++ b/server/middleware/error-handler.js
@@ -1,0 +1,8 @@
+import logger from '../../mcp-server/src/logger.js';
+
+export default function errorHandler(err, _req, res, _next) {
+	logger.error(err);
+	res.status(err.status || 500).json({
+		error: err.message || 'Internal Server Error'
+	});
+}

--- a/server/middleware/sanitize.js
+++ b/server/middleware/sanitize.js
@@ -1,0 +1,10 @@
+export default function sanitizeBody(req, _res, next) {
+	if (req.body && typeof req.body === 'object') {
+		for (const [key, value] of Object.entries(req.body)) {
+			if (typeof value === 'string') {
+				req.body[key] = value.replace(/[<>]/g, '');
+			}
+		}
+	}
+	next();
+}

--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -1,0 +1,17 @@
+import { ZodError } from 'zod';
+
+export default function validate(schema) {
+	return (req, res, next) => {
+		try {
+			const data = schema.parse(req.body);
+			req.validatedBody = data;
+			next();
+		} catch (err) {
+			if (err instanceof ZodError) {
+				res.status(400).json({ error: 'Invalid data', details: err.errors });
+			} else {
+				next(err);
+			}
+		}
+	};
+}

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1,92 +1,85 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { z } from 'zod';
 import { readJSON, writeJSON } from '../../scripts/modules/utils.js';
+import validate from '../middleware/validation.js';
+import { TaskSchema } from '../schemas/task.js';
 
 const router = express.Router();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const TASKS_FILE = process.env.TASKS_FILE || path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+const TASKS_FILE =
+	process.env.TASKS_FILE ||
+	path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
 
 function loadTasks() {
-  const data = readJSON(TASKS_FILE) || { tasks: [] };
-  return Array.isArray(data.tasks) ? data.tasks : [];
+	const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
+	return Array.isArray(data.tasks) ? data.tasks : [];
 }
 
 function saveTasks(tasks) {
-  writeJSON(TASKS_FILE, { tasks });
+	const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
+	writeJSON(TASKS_FILE, { ...data, tasks });
 }
 
-const TaskSchema = z.object({
-  title: z.string(),
-  description: z.string(),
-  status: z.string().optional(),
-  dependencies: z.array(z.number()).optional(),
-  priority: z.string().optional(),
-  details: z.string().optional(),
-  testStrategy: z.string().optional(),
-});
-
 router.get('/', (req, res, next) => {
-  try {
-    const tasks = loadTasks();
-    res.json({ tasks });
-  } catch (err) {
-    next(err);
-  }
+	try {
+		const tasks = loadTasks();
+		res.json({ tasks });
+	} catch (err) {
+		next(err);
+	}
 });
 
-router.post('/', (req, res, next) => {
-  try {
-    const data = TaskSchema.parse(req.body);
-    const tasks = loadTasks();
-    const newId = tasks.length ? Math.max(...tasks.map((t) => t.id)) + 1 : 1;
-    const newTask = { id: newId, ...data, subtasks: [] };
-    tasks.push(newTask);
-    saveTasks(tasks);
-    res.status(201).json(newTask);
-  } catch (err) {
-    next(err);
-  }
+router.post('/', validate(TaskSchema), (req, res, next) => {
+	try {
+		const data = req.validatedBody;
+		const tasks = loadTasks();
+		const newId = tasks.length ? Math.max(...tasks.map((t) => t.id)) + 1 : 1;
+		const newTask = { id: newId, ...data, subtasks: [] };
+		tasks.push(newTask);
+		saveTasks(tasks);
+		res.status(201).json(newTask);
+	} catch (err) {
+		next(err);
+	}
 });
 
-router.put('/:id', (req, res, next) => {
-  try {
-    const id = parseInt(req.params.id, 10);
-    const update = TaskSchema.partial().parse(req.body);
-    const tasks = loadTasks();
-    const index = tasks.findIndex((t) => t.id === id);
-    if (index === -1) {
-      res.status(404).json({ error: 'Task not found' });
-      return;
-    }
-    tasks[index] = { ...tasks[index], ...update };
-    saveTasks(tasks);
-    res.json(tasks[index]);
-  } catch (err) {
-    next(err);
-  }
+router.put('/:id', validate(TaskSchema.partial()), (req, res, next) => {
+	try {
+		const id = parseInt(req.params.id, 10);
+		const update = req.validatedBody;
+		const tasks = loadTasks();
+		const index = tasks.findIndex((t) => t.id === id);
+		if (index === -1) {
+			res.status(404).json({ error: 'Task not found' });
+			return;
+		}
+		tasks[index] = { ...tasks[index], ...update };
+		saveTasks(tasks);
+		res.json(tasks[index]);
+	} catch (err) {
+		next(err);
+	}
 });
 
 router.delete('/:id', (req, res, next) => {
-  try {
-    const id = parseInt(req.params.id, 10);
-    const tasks = loadTasks();
-    const index = tasks.findIndex((t) => t.id === id);
-    if (index === -1) {
-      res.status(404).json({ error: 'Task not found' });
-      return;
-    }
-    tasks.splice(index, 1);
-    saveTasks(tasks);
-    res.status(204).end();
-  } catch (err) {
-    next(err);
-  }
-
+	try {
+		const id = parseInt(req.params.id, 10);
+		const tasks = loadTasks();
+		const index = tasks.findIndex((t) => t.id === id);
+		if (index === -1) {
+			res.status(404).json({ error: 'Task not found' });
+			return;
+		}
+		tasks.splice(index, 1);
+		saveTasks(tasks);
+		res.status(204).end();
+	} catch (err) {
+		next(err);
+	}
 });
 
 export default router;

--- a/server/schemas/task.js
+++ b/server/schemas/task.js
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const TaskSchema = z.object({
+	title: z.string(),
+	description: z.string(),
+	status: z.string().optional(),
+	dependencies: z.array(z.number()).optional(),
+	priority: z.string().optional(),
+	details: z.string().optional(),
+	testStrategy: z.string().optional()
+});

--- a/server/schemas/task.json
+++ b/server/schemas/task.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"title": { "type": "string" },
+		"description": { "type": "string" },
+		"status": { "type": "string" },
+		"dependencies": {
+			"type": "array",
+			"items": { "type": "number" }
+		},
+		"priority": { "type": "string" },
+		"details": { "type": "string" },
+		"testStrategy": { "type": "string" }
+	},
+	"required": ["title", "description"],
+	"additionalProperties": false
+}

--- a/src/utils/tasks-schema.js
+++ b/src/utils/tasks-schema.js
@@ -24,4 +24,7 @@ export const taskSchema = z
 	})
 	.passthrough();
 
-export const tasksFileSchema = z.object({ tasks: z.array(taskSchema) });
+export const tasksFileSchema = z.object({
+	schemaVersion: z.number().default(1),
+	tasks: z.array(taskSchema)
+});

--- a/tests/unit/data-manager.test.js
+++ b/tests/unit/data-manager.test.js
@@ -95,6 +95,7 @@ describe('TaskMasterDataManager', () => {
 	test('validateTasksData checks structure', () => {
 		const manager = new TaskMasterDataManager();
 		const valid = {
+			schemaVersion: 1,
 			tasks: [
 				{
 					id: 1,
@@ -111,10 +112,10 @@ describe('TaskMasterDataManager', () => {
 	});
 
 	test('readTasks uses findTasksPath and stores path', () => {
-		readSpy.mockReturnValue('{"tasks": []}');
+		readSpy.mockReturnValue('{"schemaVersion":1,"tasks": []}');
 		const manager = new TaskMasterDataManager();
 		const data = manager.readTasks();
-		expect(data).toEqual({ tasks: [] });
+		expect(data).toEqual({ schemaVersion: 1, tasks: [] });
 		expect(manager.tasksPath).toBe('/project/.taskmaster/tasks/tasks.json');
 	});
 
@@ -124,6 +125,7 @@ describe('TaskMasterDataManager', () => {
 		const manager = new TaskMasterDataManager();
 		manager.tasksPath = '/project/.taskmaster/tasks/tasks.json';
 		const result = manager.writeTasks({
+			schemaVersion: 1,
 			tasks: [
 				{
 					id: 1,

--- a/tests/unit/tasks-api.test.js
+++ b/tests/unit/tasks-api.test.js
@@ -12,55 +12,56 @@ let tmpDir;
 let tasksPath;
 
 describe('tasks API', () => {
-  beforeEach(async () => {
-    tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
-    tasksPath = path.join(tmpDir, 'tasks.json');
-    fs.writeFileSync(tasksPath, JSON.stringify({ tasks: [] }, null, 2));
-    process.env.TASKS_FILE = tasksPath;
-    jest.resetModules();
-    ({ default: app } = await import('../../server/app.js'));
-  });
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+		tasksPath = path.join(tmpDir, 'tasks.json');
+		fs.writeFileSync(
+			tasksPath,
+			JSON.stringify({ schemaVersion: 1, tasks: [] }, null, 2)
+		);
+		process.env.TASKS_FILE = tasksPath;
+		jest.resetModules();
+		({ default: app } = await import('../../server/app.js'));
+	});
 
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-    delete process.env.TASKS_FILE;
-  });
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		delete process.env.TASKS_FILE;
+	});
 
-  test('GET /api/tasks returns empty list', async () => {
-    const res = await request(app).get('/api/tasks');
-    expect(res.status).toBe(200);
-    expect(res.body.tasks).toEqual([]);
-  });
+	test('GET /api/tasks returns empty list', async () => {
+		const res = await request(app).get('/api/tasks');
+		expect(res.status).toBe(200);
+		expect(res.body.tasks).toEqual([]);
+	});
 
-  test('POST /api/tasks creates task', async () => {
-    const res = await request(app)
-      .post('/api/tasks')
-      .send({ title: 'Test', description: 'Desc' });
-    expect(res.status).toBe(201);
-    expect(res.body.title).toBe('Test');
+	test('POST /api/tasks creates task', async () => {
+		const res = await request(app)
+			.post('/api/tasks')
+			.send({ title: 'Test', description: 'Desc' });
+		expect(res.status).toBe(201);
+		expect(res.body.title).toBe('Test');
 
-    const data = JSON.parse(fs.readFileSync(tasksPath, 'utf-8'));
-    expect(data.tasks.length).toBe(1);
-  });
+		const data = JSON.parse(fs.readFileSync(tasksPath, 'utf-8'));
+		expect(data.tasks.length).toBe(1);
+	});
 
-  test('PUT /api/tasks/:id updates task', async () => {
-    await request(app)
-      .post('/api/tasks')
-      .send({ title: 'Test', description: 'Desc' });
-    const res = await request(app)
-      .put('/api/tasks/1')
-      .send({ status: 'done' });
-    expect(res.status).toBe(200);
-    expect(res.body.status).toBe('done');
-  });
+	test('PUT /api/tasks/:id updates task', async () => {
+		await request(app)
+			.post('/api/tasks')
+			.send({ title: 'Test', description: 'Desc' });
+		const res = await request(app).put('/api/tasks/1').send({ status: 'done' });
+		expect(res.status).toBe(200);
+		expect(res.body.status).toBe('done');
+	});
 
-  test('DELETE /api/tasks/:id removes task', async () => {
-    await request(app)
-      .post('/api/tasks')
-      .send({ title: 'Test', description: 'Desc' });
-    const res = await request(app).delete('/api/tasks/1');
-    expect(res.status).toBe(204);
-    const data = JSON.parse(fs.readFileSync(tasksPath, 'utf-8'));
-    expect(data.tasks).toEqual([]);
-  });
+	test('DELETE /api/tasks/:id removes task', async () => {
+		await request(app)
+			.post('/api/tasks')
+			.send({ title: 'Test', description: 'Desc' });
+		const res = await request(app).delete('/api/tasks/1');
+		expect(res.status).toBe(204);
+		const data = JSON.parse(fs.readFileSync(tasksPath, 'utf-8'));
+		expect(data.tasks).toEqual([]);
+	});
 });


### PR DESCRIPTION
## Summary
- define `TaskSchema` in `server/schemas`
- add validation, sanitization and error handler middleware
- plug middleware into Express app
- persist schema version in `tasks.json`
- update utilities and tests for new schema structure

## Testing
- `npm test`
- `npm run format-check`

------
https://chatgpt.com/codex/tasks/task_e_683fdec785008329be57ea514ff05db1