### PR TITLE
Add PRD API endpoints

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from '../mcp-server/src/logger.js';
 import tasksRouter from './routes/tasks.js';
+import statusRouter from './routes/status.js';
+import prdRouter from './routes/prd.js';
+import generateTasksRouter from './routes/generate-tasks.js';
 import sanitizeBody from './middleware/sanitize.js';
 import errorHandler from './middleware/error-handler.js';
 
@@ -23,6 +26,8 @@ app.use((req, _res, next) => {
 });
 app.use(express.static(path.join(__dirname, '../ui/public')));
 app.use('/api/tasks', tasksRouter);
+app.use('/api/prd', prdRouter);
+app.use('/api/generate-tasks', generateTasksRouter);
 app.use('/api', statusRouter);
 
 // Legacy health check route

--- a/server/routes/generate-tasks.js
+++ b/server/routes/generate-tasks.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import validate from '../middleware/validation.js';
+import { GenerateTasksSchema } from '../schemas/generate-tasks.js';
+import parsePRD from '../../scripts/modules/task-manager/parse-prd.js';
+
+const router = express.Router();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PRD_FILE =
+  process.env.PRD_FILE ||
+  path.join(__dirname, '../../.taskmaster/docs/prd.txt');
+
+const TASKS_FILE =
+  process.env.TASKS_FILE ||
+  path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+
+router.post('/', validate(GenerateTasksSchema), async (req, res, next) => {
+  try {
+    const { numTasks, force, append, research } = req.validatedBody;
+    const result = await parsePRD(PRD_FILE, TASKS_FILE, numTasks, {
+      force,
+      append,
+      research,
+    });
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/routes/prd.js
+++ b/server/routes/prd.js
@@ -1,0 +1,42 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import validate from '../middleware/validation.js';
+import { PRDSchema } from '../schemas/prd.js';
+
+const router = express.Router();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PRD_FILE =
+  process.env.PRD_FILE ||
+  path.join(__dirname, '../../.taskmaster/docs/prd.txt');
+
+router.get('/', (_req, res, next) => {
+  try {
+    const content = fs.existsSync(PRD_FILE)
+      ? fs.readFileSync(PRD_FILE, 'utf8')
+      : '';
+    res.json({ content });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', validate(PRDSchema), (req, res, next) => {
+  try {
+    const { content } = req.validatedBody;
+    const dir = path.dirname(PRD_FILE);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(PRD_FILE, content, 'utf8');
+    res.json({ content });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -20,21 +20,9 @@ function loadTasks() {
 }
 
 function saveTasks(tasks) {
-	const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
-	writeJSON(TASKS_FILE, { ...data, tasks });
+        const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
+        writeJSON(TASKS_FILE, { ...data, tasks });
 }
-
-const TaskSchema = z.object({
-  title: z.string(),
-  description: z.string(),
-  status: z.string().optional(),
-  dependencies: z.array(z.number()).optional(),
-  priority: z.string().optional(),
-  agent: z.string().optional(),
-  epic: z.string().optional(),
-  details: z.string().optional(),
-  testStrategy: z.string().optional(),
-});
 
 router.get('/', (req, res, next) => {
 	try {

--- a/server/schemas/generate-tasks.js
+++ b/server/schemas/generate-tasks.js
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const GenerateTasksSchema = z.object({
+  numTasks: z.number().int().positive().optional().default(10),
+  force: z.boolean().optional().default(false),
+  append: z.boolean().optional().default(false),
+  research: z.boolean().optional().default(false),
+});

--- a/server/schemas/prd.js
+++ b/server/schemas/prd.js
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const PRDSchema = z.object({
+  content: z.string().min(1),
+});

--- a/tests/unit/prd-api.test.js
+++ b/tests/unit/prd-api.test.js
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { fileURLToPath } from 'url';
+import { jest } from '@jest/globals';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let app;
+let tmpDir;
+let prdPath;
+let tasksPath;
+
+describe('prd API', () => {
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+    prdPath = path.join(tmpDir, 'prd.txt');
+    tasksPath = path.join(tmpDir, 'tasks.json');
+    fs.writeFileSync(prdPath, 'initial');
+    fs.writeFileSync(tasksPath, JSON.stringify({ schemaVersion: 1, tasks: [] }, null, 2));
+    process.env.PRD_FILE = prdPath;
+    process.env.TASKS_FILE = tasksPath;
+    jest.unstable_mockModule('../../scripts/modules/task-manager/parse-prd.js', () => ({
+      default: jest.fn().mockResolvedValue({ success: true }),
+    }));
+    jest.resetModules();
+    ({ default: app } = await import('../../server/app.js'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.PRD_FILE;
+    delete process.env.TASKS_FILE;
+    jest.resetModules();
+  });
+
+  test('GET /api/prd returns content', async () => {
+    const res = await request(app).get('/api/prd');
+    expect(res.status).toBe(200);
+    expect(res.body.content).toBe('initial');
+  });
+
+  test('POST /api/prd updates content', async () => {
+    const res = await request(app).post('/api/prd').send({ content: 'updated' });
+    expect(res.status).toBe(200);
+    expect(fs.readFileSync(prdPath, 'utf8')).toBe('updated');
+  });
+
+  test('POST /api/generate-tasks triggers parse', async () => {
+    const { default: parsePRD } = await import('../../scripts/modules/task-manager/parse-prd.js');
+    const res = await request(app).post('/api/generate-tasks').send({ numTasks: 5 });
+    expect(res.status).toBe(200);
+    expect(parsePRD).toHaveBeenCalledWith(prdPath, tasksPath, 5, { force: false, append: false, research: false });
+  });
+});


### PR DESCRIPTION
## Summary
- expose `/api/prd` for reading and updating the PRD
- add `/api/generate-tasks` endpoint that uses existing `parsePRD` logic
- validate PRD and generation parameters with Zod schemas
- fix missing statusRouter import in `app.js`
- remove duplicate schema definition in `tasks.js`
- test new endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe3a66c90832991e2f822954c8dad