### PR TITLE
Implement MCP bridge and conflict handling

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from '../mcp-server/src/logger.js';
 import tasksRouter from './routes/tasks.js';
+import statusRouter from './routes/status.js';
+import mcpRouter from './routes/mcp.js';
 import sanitizeBody from './middleware/sanitize.js';
 import errorHandler from './middleware/error-handler.js';
 
@@ -23,6 +25,7 @@ app.use((req, _res, next) => {
 });
 app.use(express.static(path.join(__dirname, '../ui/public')));
 app.use('/api/tasks', tasksRouter);
+app.use('/api/mcp', mcpRouter);
 app.use('/api', statusRouter);
 
 // Legacy health check route

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import taskMasterCore from '../../mcp-server/src/core/task-master-core.js';
+import { broadcast } from '../websocket.js';
+
+const router = express.Router();
+
+router.post('/command', async (req, res, next) => {
+  const { command, params = {} } = req.body || {};
+  const fn = taskMasterCore[`${command}Direct`] || taskMasterCore[command];
+  if (typeof fn !== 'function') {
+    res.status(400).json({ error: 'Unknown command' });
+    return;
+  }
+  try {
+    broadcast({ type: 'commandStatus', command, status: 'started' });
+    const result = await fn(params, { source: 'mcp' });
+    broadcast({ type: 'commandStatus', command, status: 'completed' });
+    res.json(result);
+  } catch (err) {
+    broadcast({ type: 'commandStatus', command, status: 'error', message: err.message });
+    next(err);
+  }
+});
+
+export default router;

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -1,9 +1,11 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import fs from 'fs';
 import { readJSON, writeJSON } from '../../scripts/modules/utils.js';
 import validate from '../middleware/validation.js';
 import { TaskSchema } from '../schemas/task.js';
+import { broadcast } from '../websocket.js';
 
 const router = express.Router();
 
@@ -11,8 +13,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const TASKS_FILE =
-	process.env.TASKS_FILE ||
-	path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+        process.env.TASKS_FILE ||
+        path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+
+function getVersion() {
+        try {
+                return fs.statSync(TASKS_FILE).mtimeMs;
+        } catch {
+                return Date.now();
+        }
+}
 
 function loadTasks() {
 	const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
@@ -20,78 +30,88 @@ function loadTasks() {
 }
 
 function saveTasks(tasks) {
-	const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
-	writeJSON(TASKS_FILE, { ...data, tasks });
+        const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
+        writeJSON(TASKS_FILE, { ...data, tasks });
 }
 
-const TaskSchema = z.object({
-  title: z.string(),
-  description: z.string(),
-  status: z.string().optional(),
-  dependencies: z.array(z.number()).optional(),
-  priority: z.string().optional(),
-  agent: z.string().optional(),
-  epic: z.string().optional(),
-  details: z.string().optional(),
-  testStrategy: z.string().optional(),
-});
-
 router.get('/', (req, res, next) => {
-	try {
-		const tasks = loadTasks();
-		res.json({ tasks });
-	} catch (err) {
-		next(err);
-	}
+        try {
+                const tasks = loadTasks();
+                res.set('X-Tasks-Version', String(getVersion()));
+                res.json({ tasks });
+        } catch (err) {
+                next(err);
+        }
 });
 
 router.post('/', validate(TaskSchema), (req, res, next) => {
-	try {
-		const data = req.validatedBody;
-		const tasks = loadTasks();
-		const newId = tasks.length ? Math.max(...tasks.map((t) => t.id)) + 1 : 1;
-		const newTask = { id: newId, ...data, subtasks: [] };
-		tasks.push(newTask);
-		saveTasks(tasks);
-		res.status(201).json(newTask);
-	} catch (err) {
-		next(err);
-	}
+        try {
+                const clientVersion = Number(req.get('x-tasks-version'));
+                if (clientVersion && clientVersion !== getVersion()) {
+                        res.status(409).json({ error: 'Task data out of date' });
+                        return;
+                }
+                const data = req.validatedBody;
+                const tasks = loadTasks();
+                const newId = tasks.length ? Math.max(...tasks.map((t) => t.id)) + 1 : 1;
+                const newTask = { id: newId, ...data, subtasks: [] };
+                tasks.push(newTask);
+                saveTasks(tasks);
+                broadcast({ type: 'tasksUpdated', tasks });
+                res.set('X-Tasks-Version', String(getVersion()));
+                res.status(201).json(newTask);
+        } catch (err) {
+                next(err);
+        }
 });
 
 router.put('/:id', validate(TaskSchema.partial()), (req, res, next) => {
-	try {
-		const id = parseInt(req.params.id, 10);
-		const update = req.validatedBody;
-		const tasks = loadTasks();
-		const index = tasks.findIndex((t) => t.id === id);
-		if (index === -1) {
-			res.status(404).json({ error: 'Task not found' });
-			return;
-		}
-		tasks[index] = { ...tasks[index], ...update };
-		saveTasks(tasks);
-		res.json(tasks[index]);
-	} catch (err) {
-		next(err);
-	}
+        try {
+                const clientVersion = Number(req.get('x-tasks-version'));
+                if (clientVersion && clientVersion !== getVersion()) {
+                        res.status(409).json({ error: 'Task data out of date' });
+                        return;
+                }
+                const id = parseInt(req.params.id, 10);
+                const update = req.validatedBody;
+                const tasks = loadTasks();
+                const index = tasks.findIndex((t) => t.id === id);
+                if (index === -1) {
+                        res.status(404).json({ error: 'Task not found' });
+                        return;
+                }
+                tasks[index] = { ...tasks[index], ...update };
+                saveTasks(tasks);
+                broadcast({ type: 'tasksUpdated', tasks });
+                res.set('X-Tasks-Version', String(getVersion()));
+                res.json(tasks[index]);
+        } catch (err) {
+                next(err);
+        }
 });
 
 router.delete('/:id', (req, res, next) => {
-	try {
-		const id = parseInt(req.params.id, 10);
-		const tasks = loadTasks();
-		const index = tasks.findIndex((t) => t.id === id);
-		if (index === -1) {
-			res.status(404).json({ error: 'Task not found' });
-			return;
-		}
-		tasks.splice(index, 1);
-		saveTasks(tasks);
-		res.status(204).end();
-	} catch (err) {
-		next(err);
-	}
+        try {
+                const clientVersion = Number(req.get('x-tasks-version'));
+                if (clientVersion && clientVersion !== getVersion()) {
+                        res.status(409).json({ error: 'Task data out of date' });
+                        return;
+                }
+                const id = parseInt(req.params.id, 10);
+                const tasks = loadTasks();
+                const index = tasks.findIndex((t) => t.id === id);
+                if (index === -1) {
+                        res.status(404).json({ error: 'Task not found' });
+                        return;
+                }
+                tasks.splice(index, 1);
+                saveTasks(tasks);
+                broadcast({ type: 'tasksUpdated', tasks });
+                res.set('X-Tasks-Version', String(getVersion()));
+                res.status(204).end();
+        } catch (err) {
+                next(err);
+        }
 });
 
 export default router;

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -15,6 +15,37 @@ let tasks = [];
 
 let editId = null;
 
+let socket = null;
+
+function connectWebSocket() {
+        const statusEl = document.getElementById('connection-status');
+        const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+        const url = `${proto}://${location.host}`;
+        socket = new WebSocket(url);
+        socket.addEventListener('open', () => {
+                statusEl.textContent = 'Connected';
+                statusEl.classList.remove('disconnected');
+                statusEl.classList.add('connected');
+        });
+        socket.addEventListener('close', () => {
+                statusEl.textContent = 'Disconnected';
+                statusEl.classList.remove('connected');
+                statusEl.classList.add('disconnected');
+                setTimeout(connectWebSocket, 3000);
+        });
+        socket.addEventListener('message', (e) => {
+                try {
+                        const msg = JSON.parse(e.data);
+                        if (msg.type === 'tasksUpdated' && Array.isArray(msg.tasks)) {
+                                tasks = msg.tasks;
+                                renderBoard();
+                        }
+                } catch (err) {
+                        console.error('Invalid message', err);
+                }
+        });
+}
+
 const modal = document.getElementById('task-modal');
 const form = document.getElementById('task-form');
 


### PR DESCRIPTION
## Summary
- add MCP command forwarding router
- broadcast task changes and command status via websocket
- watch tasks.json for updates
- ensure concurrent task updates use version header
- connect UI WebSocket

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_683fe3e7f6448329892ecce42ac7123f