### PR TITLE
Add full workflow integration test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,10 @@ This directory contains tests for the Task Master CLI. The tests are organized i
 ## Test Structure
 
 - `unit/`: Unit tests for individual functions and components
-- `integration/`: Integration tests for testing interactions between components
+- `integration/`: Integration tests for testing interactions between components.
+  Includes a full workflow test that starts the Express server and WebSocket
+  layer to verify UI-to-backend communication, file persistence and real-time
+  updates.
 - `e2e/`: End-to-end tests for testing complete workflows
 - `fixtures/`: Test fixtures and sample data
 
@@ -41,7 +44,9 @@ Integration tests focus on testing interactions between components. These tests 
 
 ### End-to-End Tests
 
-End-to-end tests focus on testing complete workflows from a user's perspective. These tests ensure that the CLI works correctly as a whole.
+End-to-end tests focus on testing complete workflows from a user's perspective.
+Use `npm run test:e2e` to execute the shell based scenarios that exercise the CLI
+against real project files.
 
 ## Test Fixtures
 

--- a/tests/integration/full-workflow.test.js
+++ b/tests/integration/full-workflow.test.js
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+import request from 'supertest';
+import WebSocket from 'ws';
+import express from 'express';
+import { fileURLToPath } from 'url';
+import { once } from 'events';
+import { jest } from '@jest/globals';
+
+// Mock MCP router to avoid importing the full MCP core
+jest.unstable_mockModule('../../server/routes/mcp.js', () => ({
+  default: express.Router(),
+}));
+
+let app;
+let server;
+let wss;
+let port;
+let baseUrl;
+let tmpDir;
+let tasksPath;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Full workflow integration', () => {
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+    tasksPath = path.join(tmpDir, 'tasks.json');
+    fs.writeFileSync(tasksPath, JSON.stringify({ schemaVersion: 1, tasks: [] }, null, 2));
+    process.env.TASKS_FILE = tasksPath;
+    jest.resetModules();
+    ({ default: app } = await import('../../server/app.js'));
+    const initWebSocketServer = (await import('../../server/websocket.js')).default;
+    server = http.createServer(app);
+    wss = initWebSocketServer(server);
+    await new Promise((resolve) => server.listen(0, resolve));
+    port = server.address().port;
+    baseUrl = `http://localhost:${port}`;
+  });
+
+  afterAll(() => {
+    wss.close();
+    server.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.TASKS_FILE;
+  });
+
+  test('UI to backend communication and file persistence', async () => {
+    const createRes = await request(baseUrl)
+      .post('/api/tasks')
+      .send({ title: 'Task 1', description: 'desc' });
+    expect(createRes.status).toBe(201);
+
+    const listRes = await request(baseUrl).get('/api/tasks');
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.tasks.length).toBe(1);
+    expect(listRes.body.tasks[0].title).toBe('Task 1');
+
+    const data = JSON.parse(fs.readFileSync(tasksPath, 'utf8'));
+    expect(data.tasks.length).toBe(1);
+  });
+
+  test('real-time updates via WebSocket', async () => {
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await once(ws, 'open');
+    const messages = [];
+    ws.on('message', (data) => messages.push(JSON.parse(data)));
+
+    await request(baseUrl)
+      .post('/api/tasks')
+      .send({ title: 'Task 2', description: 'two' });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(messages.find((m) => m.type === 'tasksUpdated')).toBeTruthy();
+    ws.terminate();
+  });
+
+  test('error scenario: version conflict', async () => {
+    const res = await request(baseUrl)
+      .post('/api/tasks')
+      .set('X-Tasks-Version', '0')
+      .send({ title: 'Conflict', description: 'fail' });
+    expect(res.status).toBe(409);
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for UI-to-backend workflows
- document workflow integration tests in README

## Testing
- `npm test --silent` *(fails: mcp-server module export errors)*

------
https://chatgpt.com/codex/tasks/task_e_68402cca5744832980a5fefb13f83b7f