### PR TITLE
Implement Sprint Management API

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import logger from '../mcp-server/src/logger.js';
 import tasksRouter from './routes/tasks.js';
+import sprintsRouter from './routes/sprints.js';
+import agentsRouter from './routes/agents.js';
+import prdRouter from './routes/prd.js';
+import generateTasksRouter from './routes/generate-tasks.js';
 import statusRouter from './routes/status.js';
 import mcpRouter from './routes/mcp.js';
 import sanitizeBody from './middleware/sanitize.js';
@@ -25,6 +29,10 @@ app.use((req, _res, next) => {
 });
 app.use(express.static(path.join(__dirname, '../ui/public')));
 app.use('/api/tasks', tasksRouter);
+app.use('/api/agents', agentsRouter);
+app.use('/api/prd', prdRouter);
+app.use('/api/generate-tasks', generateTasksRouter);
+app.use('/api/sprints', sprintsRouter);
 app.use('/api/mcp', mcpRouter);
 app.use('/api', statusRouter);
 

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import taskMasterCore from '../../mcp-server/src/core/task-master-core.js';
+import * as taskMasterCore from '../../mcp-server/src/core/task-master-core.js';
 import { broadcast } from '../websocket.js';
 
 const router = express.Router();

--- a/server/routes/sprints.js
+++ b/server/routes/sprints.js
@@ -1,0 +1,82 @@
+import express from 'express';
+import validate from '../middleware/validation.js';
+import { SprintSchema } from '../schemas/sprint.js';
+import { broadcast } from '../websocket.js';
+import { loadSprints, saveSprints, autoPlan, computeMetrics } from '../utils/sprints.js';
+
+const router = express.Router();
+
+router.get('/', (req, res, next) => {
+  try {
+    const sprints = loadSprints();
+    res.json({ sprints });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', validate(SprintSchema), (req, res, next) => {
+  try {
+    const sprints = loadSprints();
+    const newId = sprints.length ? Math.max(...sprints.map((s) => s.id || 0)) + 1 : 1;
+    const newSprint = {
+      id: newId,
+      ...req.validatedBody,
+      createdAt: new Date().toISOString(),
+      tasks: req.validatedBody.tasks || []
+    };
+    sprints.push(newSprint);
+    saveSprints(sprints);
+    broadcast({ type: 'sprintsUpdated', sprints });
+    res.status(201).json(newSprint);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', validate(SprintSchema.partial()), (req, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const sprints = loadSprints();
+    const index = sprints.findIndex((s) => s.id === id);
+    if (index === -1) {
+      res.status(404).json({ error: 'Sprint not found' });
+      return;
+    }
+    sprints[index] = { ...sprints[index], ...req.validatedBody };
+    saveSprints(sprints);
+    broadcast({ type: 'sprintsUpdated', sprints });
+    res.json(sprints[index]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/:id/plan', (req, res, next) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const sprints = loadSprints();
+    const sprint = autoPlan(sprints, id);
+    if (!sprint) {
+      res.status(404).json({ error: 'Sprint not found' });
+      return;
+    }
+    saveSprints(sprints);
+    broadcast({ type: 'sprintsUpdated', sprints });
+    res.json(sprint);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/metrics', (req, res, next) => {
+  try {
+    const sprints = loadSprints();
+    const metrics = computeMetrics(sprints);
+    res.json({ metrics });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -54,7 +54,12 @@ router.post('/', validate(TaskSchema), (req, res, next) => {
                 const data = req.validatedBody;
                 const tasks = loadTasks();
                 const newId = tasks.length ? Math.max(...tasks.map((t) => t.id)) + 1 : 1;
-                const newTask = { id: newId, ...data, subtasks: [] };
+                const newTask = {
+                        id: newId,
+                        ...data,
+                        createdAt: new Date().toISOString(),
+                        subtasks: []
+                };
                 tasks.push(newTask);
                 saveTasks(tasks);
                 broadcast({ type: 'tasksUpdated', tasks });
@@ -80,7 +85,11 @@ router.put('/:id', validate(TaskSchema.partial()), (req, res, next) => {
                         res.status(404).json({ error: 'Task not found' });
                         return;
                 }
+                const prevStatus = tasks[index].status;
                 tasks[index] = { ...tasks[index], ...update };
+                if (update.status === 'done' && prevStatus !== 'done') {
+                        tasks[index].completedAt = new Date().toISOString();
+                }
                 saveTasks(tasks);
                 broadcast({ type: 'tasksUpdated', tasks });
                 res.set('X-Tasks-Version', String(getVersion()));

--- a/server/schemas/sprint.js
+++ b/server/schemas/sprint.js
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const SprintSchema = z.object({
+  name: z.string(),
+  goal: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  status: z.string().optional(),
+  tasks: z.array(z.number()).optional(),
+  createdAt: z.string().optional(),
+  completedAt: z.string().optional()
+});

--- a/server/utils/sprints.js
+++ b/server/utils/sprints.js
@@ -1,0 +1,50 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { readJSON, writeJSON } from '../../scripts/modules/utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const SPRINTS_FILE =
+  process.env.SPRINTS_FILE ||
+  path.join(__dirname, '../../.taskmaster/sprints.json');
+
+export const TASKS_FILE =
+  process.env.TASKS_FILE ||
+  path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+
+export function loadSprints() {
+  const data = readJSON(SPRINTS_FILE) || { sprints: [] };
+  return Array.isArray(data.sprints) ? data.sprints : [];
+}
+
+export function saveSprints(sprints) {
+  writeJSON(SPRINTS_FILE, { sprints });
+}
+
+export function loadTasks() {
+  const data = readJSON(TASKS_FILE) || { tasks: [] };
+  return Array.isArray(data.tasks) ? data.tasks : [];
+}
+
+export function autoPlan(sprints, sprintId, limit = 5) {
+  const idx = sprints.findIndex((s) => s.id === sprintId);
+  if (idx === -1) return null;
+  const tasks = loadTasks();
+  const unassigned = tasks.filter((t) => t.status !== 'done');
+  sprints[idx].tasks = unassigned.slice(0, limit).map((t) => t.id);
+  return sprints[idx];
+}
+
+export function computeMetrics(sprints) {
+  const tasks = loadTasks();
+  return sprints.map((s) => {
+    const ids = Array.isArray(s.tasks) ? s.tasks : [];
+    const total = ids.length;
+    const completed = ids.reduce((acc, id) => {
+      const t = tasks.find((t) => t.id === id);
+      return acc + (t && t.status === 'done' ? 1 : 0);
+    }, 0);
+    return { id: s.id, name: s.name, total, completed };
+  });
+}

--- a/tests/unit/sprints-api.test.js
+++ b/tests/unit/sprints-api.test.js
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { fileURLToPath } from 'url';
+import { jest } from '@jest/globals';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let app;
+let tmpDir;
+let sprintsPath;
+let tasksPath;
+
+describe('sprints API', () => {
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+    sprintsPath = path.join(tmpDir, 'sprints.json');
+    tasksPath = path.join(tmpDir, 'tasks.json');
+    fs.writeFileSync(sprintsPath, JSON.stringify({ sprints: [] }, null, 2));
+    fs.writeFileSync(tasksPath, JSON.stringify({ schemaVersion: 1, tasks: [] }, null, 2));
+    process.env.SPRINTS_FILE = sprintsPath;
+    process.env.TASKS_FILE = tasksPath;
+    jest.resetModules();
+    ({ default: app } = await import('../../server/app.js'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.SPRINTS_FILE;
+    delete process.env.TASKS_FILE;
+  });
+
+  test('GET /api/sprints returns empty list', async () => {
+    const res = await request(app).get('/api/sprints');
+    expect(res.status).toBe(200);
+    expect(res.body.sprints).toEqual([]);
+  });
+
+  test('POST /api/sprints creates sprint', async () => {
+    const res = await request(app)
+      .post('/api/sprints')
+      .send({ name: 'Sprint 1', goal: 'g' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Sprint 1');
+    const data = JSON.parse(fs.readFileSync(sprintsPath, 'utf-8'));
+    expect(data.sprints.length).toBe(1);
+  });
+
+  test('PUT /api/sprints/:id updates sprint', async () => {
+    await request(app).post('/api/sprints').send({ name: 'S1', goal: 'g' });
+    const res = await request(app)
+      .put('/api/sprints/1')
+      .send({ status: 'done' });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('done');
+  });
+
+  test('POST /api/sprints/:id/plan auto-plans sprint', async () => {
+    const tasks = [
+      { id: 1, title: 'T1', description: 'd', status: 'pending', subtasks: [] },
+      { id: 2, title: 'T2', description: 'd', status: 'done', subtasks: [] }
+    ];
+    fs.writeFileSync(tasksPath, JSON.stringify({ schemaVersion: 1, tasks }, null, 2));
+    await request(app).post('/api/sprints').send({ name: 'S1', goal: 'g' });
+    const res = await request(app).post('/api/sprints/1/plan');
+    expect(res.status).toBe(200);
+    expect(res.body.tasks).toContain(1);
+    expect(res.body.tasks).not.toContain(2);
+  });
+
+  test('GET /api/sprints/metrics returns metrics', async () => {
+    const tasks = [
+      { id: 1, title: 'T1', description: 'd', status: 'done', subtasks: [] },
+      { id: 2, title: 'T2', description: 'd', status: 'pending', subtasks: [] }
+    ];
+    fs.writeFileSync(tasksPath, JSON.stringify({ schemaVersion: 1, tasks }, null, 2));
+    await request(app).post('/api/sprints').send({ name: 'S1', goal: 'g', tasks: [1, 2] });
+    const res = await request(app).get('/api/sprints/metrics');
+    expect(res.status).toBe(200);
+    const metric = res.body.metrics.find((m) => m.id === 1);
+    expect(metric.total).toBe(2);
+    expect(metric.completed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add sprint utilities and schema
- create Sprint API with basic CRUD and metrics
- extend app server to expose sprint, agent, and PRD routes
- fix tasks API to record timestamps
- provide unit tests for sprint endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68402f0f2e9c83298aab3d90e3480452