### PR TITLE
Implement CLI integration in UI

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ import logger from '../mcp-server/src/logger.js';
 import tasksRouter from './routes/tasks.js';
 import statusRouter from './routes/status.js';
 import mcpRouter from './routes/mcp.js';
+import cliRouter from './routes/cli.js';
 import sanitizeBody from './middleware/sanitize.js';
 import errorHandler from './middleware/error-handler.js';
 
@@ -26,6 +27,7 @@ app.use((req, _res, next) => {
 app.use(express.static(path.join(__dirname, '../ui/public')));
 app.use('/api/tasks', tasksRouter);
 app.use('/api/mcp', mcpRouter);
+app.use('/api/cli', cliRouter);
 app.use('/api', statusRouter);
 
 // Legacy health check route

--- a/server/routes/cli.js
+++ b/server/routes/cli.js
@@ -1,0 +1,81 @@
+import express from 'express';
+import { exec } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import { broadcast } from '../websocket.js';
+import { readJSON } from '../../scripts/modules/utils.js';
+
+const router = express.Router();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TASKS_FILE =
+  process.env.TASKS_FILE ||
+  path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
+const HISTORY_FILE =
+  process.env.COMMAND_HISTORY_FILE ||
+  path.join(__dirname, '../../.taskmaster/command-history.json');
+
+function loadHistory() {
+  try {
+    return JSON.parse(fs.readFileSync(HISTORY_FILE, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(history) {
+  fs.writeFileSync(HISTORY_FILE, JSON.stringify(history, null, 2));
+}
+
+router.post('/', (req, res) => {
+  const { command } = req.body || {};
+  if (!command) {
+    res.status(400).json({ error: 'Command required' });
+    return;
+  }
+
+  const cmd = `node ${path.join(
+    __dirname,
+    '../../bin/task-master.js'
+  )} ${command}`;
+
+  exec(cmd, { cwd: process.cwd() }, (err, stdout, stderr) => {
+    let data = null;
+    try {
+      data = JSON.parse(stdout);
+    } catch {
+      data = null;
+    }
+
+    const entry = {
+      timestamp: new Date().toISOString(),
+      command,
+      success: !err,
+      stdout,
+      stderr: stderr.trim(),
+    };
+    const history = loadHistory();
+    history.push(entry);
+    saveHistory(history);
+
+    if (!err) {
+      try {
+        const tasks = readJSON(TASKS_FILE) || { tasks: [] };
+        broadcast({ type: 'tasksUpdated', tasks: tasks.tasks || [] });
+      } catch {
+        // ignore
+      }
+    }
+
+    res.json({ success: !err, output: stdout, error: stderr.trim(), data });
+  });
+});
+
+router.get('/history', (_req, res) => {
+  res.json({ history: loadHistory() });
+});
+
+export default router;

--- a/ui/public/app.js
+++ b/ui/public/app.js
@@ -287,3 +287,36 @@ function renderBurndownChart(data) {
 }
 
 loadMetrics();
+
+async function runCliCommand(command) {
+        const outputEl = document.getElementById('cli-output');
+        const historyEl = document.getElementById('cli-history');
+        try {
+                const res = await fetch('/api/cli', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ command })
+                });
+                const data = await res.json();
+                outputEl.textContent = data.output || data.error || '';
+                const li = document.createElement('li');
+                li.textContent = `${new Date().toLocaleTimeString()} - ${command}`;
+                historyEl.prepend(li);
+                if (data.data && data.data.tasks) {
+                        tasks = data.data.tasks;
+                        renderBoard();
+                }
+        } catch (err) {
+                outputEl.textContent = 'Error executing command';
+                console.error(err);
+        }
+}
+
+document.getElementById('cli-run').addEventListener('click', () => {
+        const input = document.getElementById('cli-input');
+        const command = input.value.trim();
+        if (command) {
+                runCliCommand(command);
+                input.value = '';
+        }
+});

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -59,6 +59,15 @@
     <canvas id="burndownChart" width="400" height="200"></canvas>
   </section>
 
+  <section class="cli">
+    <h2>CLI Command</h2>
+    <input id="cli-input" type="text" placeholder="e.g., list" />
+    <button id="cli-run">Run</button>
+    <pre id="cli-output"></pre>
+    <h3>History</h3>
+    <ul id="cli-history"></ul>
+  </section>
+
   <div id="task-modal" class="modal hidden">
     <form id="task-form" class="modal-content">
       <h3 id="modal-title">Create Task</h3>

--- a/ui/public/styles.css
+++ b/ui/public/styles.css
@@ -274,3 +274,32 @@ nav a:focus {
 .agents li {
         margin-bottom: 0.25rem;
 }
+
+.cli {
+        margin-top: 1rem;
+        background: var(--bg-alt);
+        padding: 1rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        transition: var(--transition);
+}
+
+.cli pre {
+        background: var(--bg);
+        padding: 0.5rem;
+        border-radius: 4px;
+        max-height: 200px;
+        overflow: auto;
+        margin-top: 0.5rem;
+}
+
+.cli ul {
+        list-style: none;
+        padding: 0;
+        margin-top: 0.5rem;
+}
+
+.cli li {
+        font-size: 0.9rem;
+        margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- add `/api/cli` route to run Task Master commands and store history
- expose CLI route in Express app
- provide simple web UI to run commands and show history
- broadcast task updates after commands

## Testing
- `npm test` *(fails: SyntaxError The requested module '../../mcp-server/src/core/task-master-core.js' does not provide an export named 'default')*

------
https://chatgpt.com/codex/tasks/task_e_68402f1bc9408329b39402168a075e48