### PR TITLE
Add REST API documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Welcome to the Task Master documentation. Use the links below to navigate to the
 - [Command Reference](command-reference.md) - Complete list of all available commands
 - [Task Structure](task-structure.md) - Understanding the task format and features
 - [Project Architecture](architecture.md) - High level overview of the codebase
-- [API Documentation](api/README.md) - Using Task Master programmatically
+- [API Documentation](api/README.md) - REST API reference and OpenAPI explorer
 
 ## Examples & Licensing
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,9 +1,92 @@
 # API Documentation
 
-This directory contains documentation for using Task Master as a Node module and for integrating with the MCP server.
+Task Master exposes a simple REST API used by the dashboard and MCP clients. An OpenAPI specification is provided in this folder and can be explored interactively using [ReDoc](explorer.html).
 
-- **CLI Usage** – see the main [README](../README.md#installation) for command line installation and commands.
-- **Node Module** – import functions from `scripts/` or `src/` to build custom tools.
-- **MCP Server** – the server exposed in `mcp-server/` follows the Model Control Protocol and can be extended with new tools.
+## OpenAPI
 
-Additional pages can be added under this folder to document individual modules or endpoints.
+The full specification is available at [openapi.yaml](openapi.yaml). Open it in a tool such as ReDoc or Swagger UI to browse all operations and schemas.
+
+## Usage Guidelines
+
+- The server listens on `http://localhost:3000` by default.
+- All endpoints are prefixed with `/api`.
+- Request bodies should be sent as JSON with the `Content-Type: application/json` header.
+- Most write operations return the updated resource or a status object. Errors are returned in the form `{ "error": "message" }`.
+
+## Endpoints
+
+Below is a quick reference of the most commonly used endpoints. Refer to the OpenAPI file for complete details.
+
+### Tasks
+
+- `GET /api/tasks` – list tasks
+- `POST /api/tasks` – create a new task
+- `PUT /api/tasks/{id}` – update a task
+- `DELETE /api/tasks/{id}` – remove a task
+
+Example request to create a task:
+
+```bash
+curl -X POST http://localhost:3000/api/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Research API","description":"Read docs"}'
+```
+
+### Agents
+
+- `GET /api/agents` – list agents
+- `POST /api/agents` – create an agent
+- `PUT /api/agents/{id}` – update an agent
+- `GET /api/agents/metrics` – agent performance metrics
+- `GET /api/agents/history` – assignment history
+
+### PRD
+
+- `GET /api/prd` – fetch the PRD text
+- `POST /api/prd` – replace the PRD text
+- `POST /api/generate-tasks` – parse the PRD and create tasks
+
+### Sprints
+
+- `GET /api/sprints` – list sprints
+- `POST /api/sprints` – create a sprint
+- `PUT /api/sprints/{id}` – update a sprint
+- `POST /api/sprints/{id}/plan` – auto-plan sprint tasks
+- `GET /api/sprints/metrics` – sprint statistics
+
+### CLI & MCP
+
+- `POST /api/cli` – run a Task Master CLI command
+- `GET /api/cli/history` – previous CLI runs
+- `POST /api/mcp/command` – invoke a Task Master MCP command
+
+### Status & Metrics
+
+- `GET /api/status` – overall task counts
+- `GET /api/metrics` – task completion metrics
+- `GET /api/velocity` – tasks completed per day
+- `GET /api/burndown` – burndown data
+- `GET /api/progress` – completion rate
+- `GET /api/team-performance` – stats grouped by agent
+- `GET /api/trends` – task creation/completion trends
+- `GET /api/health` – health check
+- `GET /api/ready` – readiness probe
+
+## Response Example
+
+A successful call to `GET /api/tasks` returns:
+
+```json
+{
+  "tasks": [
+    {
+      "id": 1,
+      "title": "Task title",
+      "description": "Task description",
+      "status": "pending"
+    }
+  ]
+}
+```
+
+For full schema definitions and additional endpoints see [openapi.yaml](openapi.yaml).

--- a/docs/api/explorer.html
+++ b/docs/api/explorer.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Task Master API Explorer</title>
+  <style>
+    body { margin:0; padding:0; }
+    redoc { display:block; height:100vh; }
+  </style>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+</head>
+<body>
+  <redoc spec-url="openapi.yaml"></redoc>
+</body>
+</html>

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,485 @@
+openapi: 3.0.0
+info:
+  title: Task Master API
+  version: 1.0.0
+  description: REST API for managing tasks, agents and sprints in Task Master.
+servers:
+  - url: http://localhost:3000
+paths:
+  /api/tasks:
+    get:
+      summary: List tasks
+      responses:
+        '200':
+          description: Array of tasks
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tasks:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Task'
+    post:
+      summary: Create a task
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Task'
+      responses:
+        '201':
+          description: Task created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+  /api/tasks/{id}:
+    put:
+      summary: Update a task
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Task'
+      responses:
+        '200':
+          description: Updated task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+    delete:
+      summary: Delete a task
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      responses:
+        '204':
+          description: Deleted
+  /api/agents:
+    get:
+      summary: List agents
+      responses:
+        '200':
+          description: Array of agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Agent'
+    post:
+      summary: Create agent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Agent'
+      responses:
+        '201':
+          description: Created agent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+  /api/agents/{id}:
+    put:
+      summary: Update agent
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Agent'
+      responses:
+        '200':
+          description: Updated agent
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+  /api/agents/metrics:
+    get:
+      summary: Agent performance metrics
+      responses:
+        '200':
+          description: Metrics data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/agents/history:
+    get:
+      summary: Agent assignment history
+      responses:
+        '200':
+          description: History data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/prd:
+    get:
+      summary: Get PRD content
+      responses:
+        '200':
+          description: PRD text
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: string
+    post:
+      summary: Update PRD content
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                content:
+                  type: string
+      responses:
+        '200':
+          description: Saved PRD
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  content:
+                    type: string
+  /api/generate-tasks:
+    post:
+      summary: Generate tasks from PRD
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateTasksOptions'
+      responses:
+        '200':
+          description: Generation result
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/sprints:
+    get:
+      summary: List sprints
+      responses:
+        '200':
+          description: Array of sprints
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sprints:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Sprint'
+    post:
+      summary: Create sprint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Sprint'
+      responses:
+        '201':
+          description: Created sprint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sprint'
+  /api/sprints/{id}:
+    put:
+      summary: Update sprint
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Sprint'
+      responses:
+        '200':
+          description: Updated sprint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sprint'
+  /api/sprints/{id}/plan:
+    post:
+      summary: Autoplan sprint
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+      responses:
+        '200':
+          description: Planned sprint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sprint'
+  /api/sprints/metrics:
+    get:
+      summary: Sprint metrics
+      responses:
+        '200':
+          description: Metrics
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/mcp/command:
+    post:
+      summary: Execute MCP command
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+                params:
+                  type: object
+      responses:
+        '200':
+          description: Command result
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/cli:
+    post:
+      summary: Execute CLI command
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+      responses:
+        '200':
+          description: CLI output
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/cli/history:
+    get:
+      summary: Get CLI command history
+      responses:
+        '200':
+          description: History
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/status:
+    get:
+      summary: Task status summary
+      responses:
+        '200':
+          description: Status data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/metrics:
+    get:
+      summary: Task metrics
+      responses:
+        '200':
+          description: Metrics data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/velocity:
+    get:
+      summary: Velocity over time
+      responses:
+        '200':
+          description: Velocity data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/burndown:
+    get:
+      summary: Burndown chart data
+      responses:
+        '200':
+          description: Burndown
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/progress:
+    get:
+      summary: Overall progress
+      responses:
+        '200':
+          description: Progress data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/team-performance:
+    get:
+      summary: Team performance metrics
+      responses:
+        '200':
+          description: Performance data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/trends:
+    get:
+      summary: Trends data
+      responses:
+        '200':
+          description: Trends data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/ready:
+    get:
+      summary: Readiness check
+      responses:
+        '200':
+          description: Ready
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Task:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+        priority:
+          type: string
+        agent:
+          type: string
+        epic:
+          type: string
+        details:
+          type: string
+        testStrategy:
+          type: string
+        createdAt:
+          type: string
+        completedAt:
+          type: string
+    Agent:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        status:
+          type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+    Sprint:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        goal:
+          type: string
+        startDate:
+          type: string
+        endDate:
+          type: string
+        status:
+          type: string
+        tasks:
+          type: array
+          items:
+            type: integer
+        createdAt:
+          type: string
+        completedAt:
+          type: string
+    GenerateTasksOptions:
+      type: object
+      properties:
+        numTasks:
+          type: integer
+        force:
+          type: boolean
+        append:
+          type: boolean
+        research:
+          type: boolean


### PR DESCRIPTION
## Summary
- document available API endpoints and usage
- include OpenAPI spec for REST interface
- link new docs from the main documentation
- add interactive OpenAPI explorer

## Testing
- `npm run format-check` *(fails: Formatter would have printed content)*
- `npm test` *(fails: Jest encountered unexpected tokens)*

------
https://chatgpt.com/codex/tasks/task_e_6840c15d453c8329bd046f96e5b96784